### PR TITLE
install_name

### DIFF
--- a/config/desktop_osx.cfg
+++ b/config/desktop_osx.cfg
@@ -6,6 +6,6 @@ BuildFlags.linkerFlags = ${BuildFlags.linkerFlags} -stdlib=libc++
 BuildFlags.defines = ${BuildFlags.defines} $
   __MACOSX_CORE__ HAVE_GETTIMEOFDAY
 BuildFlags.linkerFlags = ${BuildFlags.linkerFlags} $
-  -framework CoreFoundation -framework CoreAudio
+  -framework CoreFoundation -framework CoreAudio -install_name @loader_path/libmethcla.dylib
 
 include ${la.methc.sourceDir}/config/sndfile_api_extaudiofile.cfg


### PR DESCRIPTION
added install_name flag for desktop osx config to make sure dylib will be loaded from runtime path and @loader_path is set
