### PR TITLE
Clamp number of input channels to what is available

### DIFF
--- a/platform/rtaudio/Methcla/Audio/IO/RtAudioDriver.cpp
+++ b/platform/rtaudio/Methcla/Audio/IO/RtAudioDriver.cpp
@@ -53,8 +53,14 @@ RtAudioDriver::RtAudioDriver(Options options)
     else if (options.numInputs > 0)
     {
         iParams.deviceId = m_audio.getDefaultInputDevice();
-        iParams.nChannels = options.numInputs;
-        iParamsPtr = &iParams;
+        int available = m_audio.getDeviceInfo(iParams.deviceId).inputChannels;
+        // clamp to number of available channels
+        if (options.numInputs <= available)
+            iParams.nChannels = options.numInputs;
+        else
+            iParams.nChannels = options.numInputs = available;
+        if (0 < iParams.nChannels)
+            iParamsPtr = &iParams;
     }
 
     if (options.numOutputs == -1)


### PR DESCRIPTION
This fixes the following exception on the Raspberry Pi:
terminate called after throwing an instance of 'std::runtime_error'
  what():  RtApiAlsa::probeDeviceOpen: pcm device (hw:0,0) won't open for input.
Finished.