### PR TITLE
Make RtAudio optional with DummyDriver fallback

### DIFF
--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -1,2 +1,10 @@
-add_subdirectory(rtaudio)
+if(METHCLA_ENABLE_RTAUDIO)
+    add_subdirectory(rtaudio)
+else()
+    add_library(driver_dummy STATIC DummyPlatform.cpp)
+    target_include_directories(driver_dummy PRIVATE
+        ../include
+        ../src
+    )
+endif()
 

--- a/platform/DummyPlatform.cpp
+++ b/platform/DummyPlatform.cpp
@@ -1,0 +1,8 @@
+#include "Methcla/Audio/IO/DummyDriver.hpp"
+#include "Methcla/Platform.hpp"
+
+Methcla::Audio::IO::Driver*
+Methcla::Platform::defaultAudioDriver(Methcla::Audio::IO::Driver::Options options)
+{
+    return new Methcla::Audio::IO::DummyDriver(options);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,10 +74,16 @@ target_include_directories(methcla
     ../external_libraries/boost
 )
 
+if(METHCLA_ENABLE_RTAUDIO)
+    set(methcla_driver driver_rtaudio)
+else()
+    set(methcla_driver driver_dummy)
+endif()
+
 target_link_libraries(methcla
     PRIVATE
     tlsf
-    driver_rtaudio)
+    ${methcla_driver})
 
 if (LINUX)
     target_link_libraries(methcla


### PR DESCRIPTION
## Summary

- Adds `METHCLA_ENABLE_RTAUDIO` CMake option (default `ON`)
- When `OFF`, `platform/` builds `driver_dummy` from `DummyPlatform.cpp`, returning a `DummyDriver` as the default audio driver
- `src/CMakeLists.txt` selects `driver_rtaudio` or `driver_dummy` at configure time via a local variable

Closes issue #03 (RtAudio optional with DummyDriver fallback).

## Test plan

- [x] `cmake --preset debug` (default, RtAudio ON) — configures and builds without errors
- [x] `ctest --preset debug` with RtAudio ON — all tests pass
- [x] `cmake --preset debug -DMETHCLA_ENABLE_RTAUDIO=OFF` — configures and builds `driver_dummy` without errors
- [x] `ctest --preset debug` with RtAudio OFF — all tests pass