### PR TITLE
#120: methcla target PUBLIC/PRIVATE structure and methcla::methcla alias

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,8 +83,7 @@ target_compile_options(methcla PRIVATE
 )
 
 if (LINUX)
-    target_link_libraries(methcla PRIVATE atomic)
-    target_link_libraries(methcla PUBLIC dl pthread)
+    target_link_libraries(methcla PUBLIC atomic dl pthread)
 endif ()
 
 add_library(methcla::methcla ALIAS methcla)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,20 +53,14 @@ set(sources
 add_library(methcla ${sources})
 
 target_include_directories(methcla PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
-target_include_directories(methcla
-    PRIVATE
+target_include_directories(methcla PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     ../external_libraries
-)
-
-target_include_directories(methcla
-    SYSTEM PRIVATE
-    ../external_libraries/boost
 )
 
 if(METHCLA_ENABLE_RTAUDIO)
@@ -76,12 +70,12 @@ else()
 endif()
 
 target_link_libraries(methcla
-    PUBLIC
-    oscpp::oscpp
+    PUBLIC oscpp::oscpp
     PRIVATE
-    tinydir
-    tlsf
-    ${methcla_driver})
+        boost_headers
+        tinydir
+        tlsf
+        ${methcla_driver})
 
 # GCC false positives triggered by third-party headers (boost::lockfree, tinydir)
 target_compile_options(methcla PRIVATE
@@ -89,10 +83,8 @@ target_compile_options(methcla PRIVATE
 )
 
 if (LINUX)
-    target_link_libraries(methcla
-        PUBLIC
-        atomic
-        dl
-        pthread
-    )
+    target_link_libraries(methcla PRIVATE atomic)
+    target_link_libraries(methcla PUBLIC dl pthread)
 endif ()
+
+add_library(methcla::methcla ALIAS methcla)


### PR DESCRIPTION
## Summary

- Switch public `target_include_directories` to use `CMAKE_SOURCE_DIR` (canonical root path)
- Replace raw `SYSTEM PRIVATE ../external_libraries/boost` with the `boost_headers` INTERFACE target linked `PRIVATE`
- Move `tlsf`, `tinydir`, `boost_headers`, and the audio driver to `PRIVATE` (they are implementation details not exposed in public headers)
- On Linux: `atomic` → `PRIVATE`; `dl` and `pthread` remain `PUBLIC`
- Add `methcla::methcla` ALIAS target
- `oscpp::oscpp` remains `PUBLIC` because it appears in installed public headers (`include/methcla/detail/result.hpp` includes `<oscpp/server.hpp>`)

## Test plan

- [x] `cmake --build --preset debug` produces `libmethcla.a` without errors
- [x] `cmake --build --preset release` produces `libmethcla.a` without errors