### PR TITLE
#120: Scope warning flags per-target via methcla_target_warnings()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,13 @@ set(methcla_warnings
     -Wstrict-aliasing
     -Werror)
 
-add_compile_options(
-    "$<$<CXX_COMPILER_ID:Clang>:${methcla_warnings}>"
-    "$<$<CXX_COMPILER_ID:AppleClang>:${methcla_warnings}>"
-    "$<$<CXX_COMPILER_ID:GNU>:${methcla_warnings}>"
-)
+function(methcla_target_warnings target)
+    target_compile_options(${target} PRIVATE
+        "$<$<CXX_COMPILER_ID:Clang>:${methcla_warnings}>"
+        "$<$<CXX_COMPILER_ID:AppleClang>:${methcla_warnings}>"
+        "$<$<CXX_COMPILER_ID:GNU>:${methcla_warnings}>"
+    )
+endfunction()
 
 include(CTest)
 include(cmake/dependencies.cmake)

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -6,5 +6,6 @@ else()
         ../include
         ../src
     )
+    methcla_target_warnings(driver_dummy)
 endif()
 

--- a/platform/rtaudio/CMakeLists.txt
+++ b/platform/rtaudio/CMakeLists.txt
@@ -23,3 +23,5 @@ target_link_libraries(driver_rtaudio
     PRIVATE
     oscpp::oscpp
 )
+
+methcla_target_warnings(driver_rtaudio)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -34,6 +34,7 @@ foreach(plugin ${plugins})
         $<INSTALL_INTERFACE:include>
     )
     target_link_libraries(${plugin_target} PRIVATE oscpp::oscpp)
+    methcla_target_warnings(${plugin_target})
     if (plugin MATCHES ".*\.c$")
         # C99 doesn't allow to not declare a parameter name
         set(c99_warnings -Wno-unused-parameter)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,4 +86,6 @@ if (LINUX)
     target_link_libraries(methcla PUBLIC atomic dl pthread)
 endif ()
 
+methcla_target_warnings(methcla)
+
 add_library(methcla::methcla ALIAS methcla)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(methcla_tests PRIVATE
     GTest::gtest
     methcla
 )
+methcla_target_warnings(methcla_tests)
 
 add_test(methcla_tests methcla_tests)
 
@@ -58,6 +59,7 @@ target_link_libraries(methcla_engine_tests PRIVATE
     GTest::gtest
     methcla
 )
+methcla_target_warnings(methcla_engine_tests)
 
 add_test(methcla_engine_tests methcla_engine_tests)
 


### PR DESCRIPTION
## Summary

- Replace global `add_compile_options()` in root `CMakeLists.txt` with a `methcla_target_warnings()` helper function
- Apply the helper to every first-party target: `methcla`, `driver_dummy`, `driver_rtaudio`, all plugins, and both test executables
- Third-party targets (`tlsf`, `gtest`, `oscpp`) intentionally excluded
- Fix ordering of `sine.c` plugin suppression flags: `methcla_target_warnings()` must come before `-Wno-unused-parameter` so the suppression correctly overrides `-Wall` on Clang/GCC

Closes #120.

## Test plan

- [x] `cmake --build --preset debug` — clean build, all targets
- [x] `cmake --build --preset release` — clean build, all targets
- [x] `ctest --preset debug` — 2/2 tests pass