### PR TITLE
#123: Install and export targets (methcla::methcla via find_package)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ function(methcla_target_warnings target)
     )
 endfunction()
 
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 include(CTest)
 include(cmake/dependencies.cmake)
 
@@ -36,3 +38,17 @@ add_subdirectory(src)
 if(METHCLA_BUILD_TESTS)
     add_subdirectory(tests)
 endif()
+
+install(EXPORT methclaTargets
+    NAMESPACE methcla::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/methcla)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/methclaConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+
+install(FILES
+    cmake/methclaConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/methclaConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/methcla)

--- a/cmake/methclaConfig.cmake
+++ b/cmake/methclaConfig.cmake
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+find_dependency(oscpp)
+include("${CMAKE_CURRENT_LIST_DIR}/methclaTargets.cmake")

--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(METHCLA_ENABLE_RTAUDIO)
     add_subdirectory(rtaudio)
 else()
-    add_library(driver_dummy STATIC DummyPlatform.cpp)
+    add_library(driver_dummy OBJECT DummyPlatform.cpp)
     target_include_directories(driver_dummy PRIVATE
         ../include
         ../src

--- a/platform/rtaudio/CMakeLists.txt
+++ b/platform/rtaudio/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(PkgConfig)
 
 pkg_check_modules(rtaudio rtaudio REQUIRED IMPORTED_TARGET)
 
-add_library(driver_rtaudio STATIC
+add_library(driver_rtaudio OBJECT
     Methcla/Audio/IO/RtAudioDriver.cpp
 )
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -10,6 +10,8 @@ function(add_methcla_plugin name source)
     )
     target_link_libraries(${target} PRIVATE oscpp::oscpp)
     methcla_target_warnings(${target})
+    install(TARGETS ${target}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/methcla/plugins)
     if (source MATCHES ".*\\.c$")
         target_compile_options(${target} PRIVATE
             "$<$<CXX_COMPILER_ID:Clang>:-Wno-unused-parameter>"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,10 +52,42 @@ set(sources
 
 add_library(methcla ${sources})
 
+target_sources(methcla PUBLIC
+    FILE_SET HEADERS
+    BASE_DIRS ${CMAKE_SOURCE_DIR}/include
+    FILES
+        ${CMAKE_SOURCE_DIR}/include/methcla/common.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/detail.hpp
+        ${CMAKE_SOURCE_DIR}/include/methcla/detail/result.hpp
+        ${CMAKE_SOURCE_DIR}/include/methcla/engine.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/engine.hpp
+        ${CMAKE_SOURCE_DIR}/include/methcla/file.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/file.hpp
+        ${CMAKE_SOURCE_DIR}/include/methcla/log.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/log.hpp
+        ${CMAKE_SOURCE_DIR}/include/methcla/platform/ios.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/platform/rtaudio.hpp
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugin.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugin.hpp
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/disksampler.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/node_control.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/patch_cable.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/sampler.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/sine.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/soundfile_api_dummy.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/soundfile_api_extaudiofile.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/soundfile_api_libsndfile.h
+        ${CMAKE_SOURCE_DIR}/include/methcla/types.h
+)
+
 target_include_directories(methcla PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+install(TARGETS methcla EXPORT methclaTargets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    FILE_SET HEADERS DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 target_include_directories(methcla PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -72,10 +104,10 @@ endif()
 target_link_libraries(methcla
     PUBLIC oscpp::oscpp
     PRIVATE
-        boost_headers
-        tinydir
-        tlsf
-        ${methcla_driver})
+        $<BUILD_INTERFACE:boost_headers>
+        $<BUILD_INTERFACE:tinydir>
+        $<BUILD_INTERFACE:tlsf>
+        $<BUILD_INTERFACE:${methcla_driver}>)
 
 # GCC false positives triggered by third-party headers (boost::lockfree, tinydir)
 target_compile_options(methcla PRIVATE


### PR DESCRIPTION
Closes #123.

## Summary

- `GNUInstallDirs` + `CMakePackageConfigHelpers` in root `CMakeLists.txt`
- `FILE_SET HEADERS` + `install(TARGETS methcla EXPORT methclaTargets …)` in `src/`
- Plugin MODULE targets installed to `${LIBDIR}/methcla/plugins/`
- `cmake/methclaConfig.cmake` calls `find_dependency(oscpp)` then includes the generated `methclaTargets.cmake`
- `methclaConfigVersion.cmake` generated via `write_basic_package_version_file` with `SameMajorVersion` compatibility
- `driver_dummy` and `driver_rtaudio` promoted from STATIC → OBJECT so their object code is merged into `libmethcla.a`; avoids exporting internal targets and ensures a single archive is sufficient for consumers
- Private build-only deps wrapped in `$<BUILD_INTERFACE:…>` to exclude them from the exported target interface

## Notes

Consumers using the RtAudio driver will still need to separately locate and link against `librtaudio` (e.g. via `pkg_check_modules(rtaudio REQUIRED rtaudio)`), since it is a system shared library. This was always the case; the change here just makes the install tree self-consistent.

## Test plan

- [ ] `cmake --install build/release --prefix /tmp/methcla-install` completes without errors
- [ ] Install tree contains `include/methcla/*.h`, `lib/libmethcla.a`, `lib/cmake/methcla/methclaConfig.cmake`, plugin `.dylib`/`.so` files under `lib/methcla/plugins/`
- [ ] `find_package(methcla REQUIRED)` in a fresh CMake project pointing at the install prefix succeeds
- [ ] Imported `methcla::methcla` carries the correct include path automatically
- [ ] Consumer executable using `#include <methcla/engine.h>` compiles and links