### PR TITLE
#124: Verify add_subdirectory and find_package consumption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,14 @@ jobs:
       - run: cmake --preset ${{ matrix.preset }} -DMETHCLA_ENABLE_RTAUDIO=OFF
       - run: cmake --build build/${{ matrix.preset }} --config ${{ matrix.build_type }}
       - run: ctest --test-dir build/${{ matrix.preset }} -C ${{ matrix.build_type }} --output-on-failure
+      - run: cmake --install build/${{ matrix.preset }} --prefix ${{ github.workspace }}/install --config ${{ matrix.build_type }}
+      - name: Consumer A (add_subdirectory)
+        run: |
+          cmake -S tests/consumers/add_subdirectory -B build/consumer-a \
+            -DMETHCLA_BUILD_TESTS=OFF -DMETHCLA_ENABLE_RTAUDIO=OFF
+          cmake --build build/consumer-a --config ${{ matrix.build_type }}
+      - name: Consumer B (find_package)
+        run: |
+          cmake -S tests/consumers/find_package -B build/consumer-b \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install
+          cmake --build build/consumer-b --config ${{ matrix.build_type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,15 @@ jobs:
           cmake -S tests/consumers/find_package -B build/consumer-b \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install
           cmake --build build/consumer-b --config ${{ matrix.build_type }}
+
+  all-passed:
+    needs: build
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check all matrix jobs passed
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "build matrix failed"
+            exit 1
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.24)
 
 project(methcla VERSION 0.3.0)
 
+set(METHCLA_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
 option(METHCLA_ENABLE_RTAUDIO "Enable RtAudio audio driver" ON)
 option(METHCLA_BUILD_TESTS "Build the test suite" ${PROJECT_IS_TOP_LEVEL})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,34 +54,34 @@ add_library(methcla ${sources})
 
 target_sources(methcla PUBLIC
     FILE_SET HEADERS
-    BASE_DIRS ${CMAKE_SOURCE_DIR}/include
+    BASE_DIRS ${METHCLA_SOURCE_DIR}/include
     FILES
-        ${CMAKE_SOURCE_DIR}/include/methcla/common.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/detail.hpp
-        ${CMAKE_SOURCE_DIR}/include/methcla/detail/result.hpp
-        ${CMAKE_SOURCE_DIR}/include/methcla/engine.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/engine.hpp
-        ${CMAKE_SOURCE_DIR}/include/methcla/file.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/file.hpp
-        ${CMAKE_SOURCE_DIR}/include/methcla/log.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/log.hpp
-        ${CMAKE_SOURCE_DIR}/include/methcla/platform/ios.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/platform/rtaudio.hpp
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugin.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugin.hpp
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/disksampler.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/node_control.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/patch_cable.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/sampler.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/sine.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/soundfile_api_dummy.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/soundfile_api_extaudiofile.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/plugins/soundfile_api_libsndfile.h
-        ${CMAKE_SOURCE_DIR}/include/methcla/types.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/common.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/detail.hpp
+        ${METHCLA_SOURCE_DIR}/include/methcla/detail/result.hpp
+        ${METHCLA_SOURCE_DIR}/include/methcla/engine.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/engine.hpp
+        ${METHCLA_SOURCE_DIR}/include/methcla/file.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/file.hpp
+        ${METHCLA_SOURCE_DIR}/include/methcla/log.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/log.hpp
+        ${METHCLA_SOURCE_DIR}/include/methcla/platform/ios.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/platform/rtaudio.hpp
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugin.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugin.hpp
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugins/disksampler.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugins/node_control.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugins/patch_cable.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugins/sampler.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugins/sine.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugins/soundfile_api_dummy.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugins/soundfile_api_extaudiofile.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/plugins/soundfile_api_libsndfile.h
+        ${METHCLA_SOURCE_DIR}/include/methcla/types.h
 )
 
 target_include_directories(methcla PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${METHCLA_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 

--- a/tests/consumers/README.md
+++ b/tests/consumers/README.md
@@ -1,0 +1,30 @@
+# Consumer tests
+
+Minimal projects that verify the two supported consumption modes build end-to-end without the consumer adding any include paths or library flags manually.
+
+## Consumer A — `add_subdirectory`
+
+```sh
+cmake -S tests/consumers/add_subdirectory -B /tmp/consumer-a -DMETHCLA_BUILD_TESTS=OFF
+cmake --build /tmp/consumer-a --target consumer
+/tmp/consumer-a/consumer
+```
+
+## Consumer B — `find_package`
+
+Requires methcla to be installed first:
+
+```sh
+cmake -S . -B /tmp/methcla-build -DMETHCLA_BUILD_TESTS=OFF
+cmake --build /tmp/methcla-build
+cmake --install /tmp/methcla-build --prefix /tmp/methcla-install
+```
+
+Then configure and build the consumer:
+
+```sh
+cmake -S tests/consumers/find_package -B /tmp/consumer-b \
+      -DCMAKE_PREFIX_PATH=/tmp/methcla-install
+cmake --build /tmp/consumer-b --target consumer
+/tmp/consumer-b/consumer
+```

--- a/tests/consumers/add_subdirectory/CMakeLists.txt
+++ b/tests/consumers/add_subdirectory/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.24)
+project(methcla_consumer_add_subdirectory C CXX)
+
+add_subdirectory(../../.. methcla)
+
+add_executable(consumer main.c)
+target_link_libraries(consumer PRIVATE methcla::methcla)

--- a/tests/consumers/add_subdirectory/main.c
+++ b/tests/consumers/add_subdirectory/main.c
@@ -1,0 +1,7 @@
+#include <methcla/engine.h>
+#include <stdio.h>
+
+int main(void) {
+    printf("methcla version: %s\n", methcla_version());
+    return 0;
+}

--- a/tests/consumers/find_package/CMakeLists.txt
+++ b/tests/consumers/find_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.24)
+project(methcla_consumer_find_package C CXX)
+
+find_package(methcla REQUIRED)
+
+add_executable(consumer main.c)
+target_link_libraries(consumer PRIVATE methcla::methcla)

--- a/tests/consumers/find_package/main.c
+++ b/tests/consumers/find_package/main.c
@@ -1,0 +1,7 @@
+#include <methcla/engine.h>
+#include <stdio.h>
+
+int main(void) {
+    printf("methcla version: %s\n", methcla_version());
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Adds `tests/consumers/add_subdirectory` and `tests/consumers/find_package` — two minimal standalone consumer projects that verify both consumption modes build end-to-end with no manual include/link flags in the consumer.
- Fixes a latent bug in `src/CMakeLists.txt` where `CMAKE_SOURCE_DIR` was used for the methcla include directory. `CMAKE_SOURCE_DIR` always points to the top-level project root, so under `add_subdirectory` consumption it pointed at the consumer's directory instead of methcla's. Fixed by capturing `METHCLA_SOURCE_DIR` at `project()` time in the root `CMakeLists.txt`.

## Test plan

- [ ] Consumer A (`add_subdirectory`): `cmake -S tests/consumers/add_subdirectory -B /tmp/ca -DMETHCLA_BUILD_TESTS=OFF && cmake --build /tmp/ca --target consumer && /tmp/ca/consumer` prints `methcla version: 0.3.0`
- [ ] Consumer B (`find_package`): build+install methcla, then `cmake -S tests/consumers/find_package -B /tmp/cb -DCMAKE_PREFIX_PATH=/tmp/methcla-install && cmake --build /tmp/cb --target consumer && /tmp/cb/consumer` prints `methcla version: 0.3.0`
- [ ] Main project still configures and builds with `METHCLA_BUILD_TESTS=ON`

Closes #124