### PR TITLE
#81: Fix implicit NodeId conversions broken by explicit constructor

### DIFF
--- a/include/methcla/engine.hpp
+++ b/include/methcla/engine.hpp
@@ -60,7 +60,7 @@ namespace Methcla {
     class NodeId : public detail::Id<NodeId, int32_t>
     {
     public:
-        NodeId(int32_t id)
+        explicit NodeId(int32_t id)
         : Id<NodeId, int32_t>(id)
         {}
         NodeId()
@@ -85,7 +85,7 @@ namespace Methcla {
     public:
         // Inheriting constructors not supported by clang 3.2
         // using NodeId::NodeId;
-        GroupId(int32_t id)
+        explicit GroupId(int32_t id)
         : NodeId(id)
         {}
         GroupId()
@@ -96,7 +96,7 @@ namespace Methcla {
     class SynthId : public NodeId
     {
     public:
-        SynthId(int32_t id)
+        explicit SynthId(int32_t id)
         : NodeId(id)
         {}
         SynthId()
@@ -107,7 +107,7 @@ namespace Methcla {
     class AudioBusId : public detail::Id<AudioBusId, int32_t>
     {
     public:
-        AudioBusId(int32_t id)
+        explicit AudioBusId(int32_t id)
         : Id<AudioBusId, int32_t>(id)
         {}
         AudioBusId()

--- a/include/methcla/engine.hpp
+++ b/include/methcla/engine.hpp
@@ -879,7 +879,7 @@ namespace Methcla {
                 .openMessage("/node/free", 1)
                 .int32(node.id())
                 .closeMessage();
-            m_engine->nodeIdAllocator().free(node.id());
+            m_engine->nodeIdAllocator().free(node);
         }
 
         void whenDone(SynthId synth, NodeDoneFlags flags)

--- a/tests/methcla_engine_tests.cpp
+++ b/tests/methcla_engine_tests.cpp
@@ -45,7 +45,7 @@ TEST(Methcla_Engine, Freeing_invalid_node_id_should_not_crash)
     auto engine = std::unique_ptr<Methcla::Engine>(new Methcla::Engine());
 
     engine->start();
-    engine->free(-1);
+    engine->free(Methcla::NodeId(-1));
     sleepFor(0.25);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #81 (Make NodeId, GroupId, SynthId, AudioBusId constructors explicit).

- `include/methcla/engine.hpp`: pass `node` directly to `nodeIdAllocator().free()` instead of `node.id()` — `NodeId::NodeId(int32_t)` is now explicit so the implicit conversion from `int` no longer compiles
- `tests/methcla_engine_tests.cpp`: use `NodeId(-1)` explicitly in `engine->free()` call

## Test plan

- [x] Builds cleanly on macOS (Clang/AppleClang)
- [x] All tests pass (`methcla_tests`, `methcla_engine_tests`)